### PR TITLE
Fix platform-specific file separator error on Windows

### DIFF
--- a/lib/commands/fly.js
+++ b/lib/commands/fly.js
@@ -26,7 +26,7 @@ module.exports = function(){
         'To ensure that this process goes smoothly please review the prerequisites: https://github.com/Solid-Interactive/grasshopper-cli ');
 
     inquirer.prompt(questions, function( answers ) {
-        var appName = process.cwd().substr((process.cwd().lastIndexOf('/') + 1), (process.cwd().length - process.cwd().lastIndexOf('/'))),
+        var appName = process.cwd().substr((process.cwd().lastIndexOf(path.sep) + 1), (process.cwd().length - process.cwd().lastIndexOf(path.sep))),
             appId = appName.toLowerCase().replace(/ /g,''),
             config = {
                 project: {


### PR DESCRIPTION
The previous one generate an error on Windows. This fix should make it friendly for Unix & Windows.

Using path.sep instead of '/'
